### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/docs/goldwasher.js.html
+++ b/docs/goldwasher.js.html
@@ -33,7 +33,7 @@ var S = require('string');
 var R = require('ramda');
 var Joi = require('joi');
 var cheerio = require('cheerio');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var js2xmlparser = require('js2xmlparser');
 var Feed = require('feed');
 

--- a/lib/goldwasher.js
+++ b/lib/goldwasher.js
@@ -6,7 +6,7 @@ var S = require('string');
 var R = require('ramda');
 var Joi = require('joi');
 var cheerio = require('cheerio');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var js2xmlparser = require('js2xmlparser');
 var Feed = require('feed');
 

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "feed": "^0.3.0",
     "joi": "^8.0.5",
     "js2xmlparser": "^1.0.0",
-    "node-uuid": "^1.4.7",
     "ramda": "^0.21.0",
     "string": "^3.1.3",
+    "uuid": "^3.0.0",
     "validator": "^5.2.0"
   },
   "repository": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.